### PR TITLE
Q&A: How can I disable displaying the data points

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ Q: "How can I modify the plot to look like..."
 A: Most modifications can be done using the function handles. See the function help and the example function, NBP_example
 
 
+Q: How can I disable displaying the data points?
+<br />
+A: H=notBoxPlot(data,'jitter',0.6); d=[H.data]; set(d,'Visible','off')
+
 ## Included functions
 - notBoxPlot.m - generates plots as shown in screenshot
 - NBP.SEM_calc.m - calculate standard error of the mean. Provided as a separate function file so that it can be used for other purposes.


### PR DESCRIPTION
I had this question so I thought I'd add it to your FAQ section. 

Q: How can I disable displaying the data points? 
A: H=notBoxPlot(data,'jitter',0.6); d=[H.data]; set(d,'Visible','off')

I love your tool and the examples! However, this behavior was not in any of the examples and I was wondering the correct way to do it for your tool for a while.